### PR TITLE
Fix rendering issues when code blocks are in a bullet point item

### DIFF
--- a/lib/isodoc/iso/html/style-human.scss
+++ b/lib/isodoc/iso/html/style-human.scss
@@ -409,13 +409,13 @@ ul li {
     list-style: none;
   }
 
-  ul > li > p:first-child:before {
-    content: "—";
-    display: inline-block;
-    width: 1em;
-    margin-left: -1.5em;
-    margin-right: 0.5em;
-  }
+ul > li > p:first-child:before {
+  content: "—";
+  display: inline-block;
+  width: 1em;
+  margin-left: -1.5em;
+  margin-right: 0.5em;
+}
 
   li p {
       /* display: inline-block; */

--- a/lib/isodoc/iso/html/style-human.scss
+++ b/lib/isodoc/iso/html/style-human.scss
@@ -408,8 +408,8 @@ p.Terms {
 ul li {
     list-style: none;
   }
-  
-  ul > li > p:before {
+
+  ul > li > p:first-child:before {
     content: "—";
     display: inline-block;
     width: 1em;

--- a/lib/isodoc/iso/html/style-iso.scss
+++ b/lib/isodoc/iso/html/style-iso.scss
@@ -251,13 +251,13 @@ h2 p {
     list-style: none;
   }
   
-  ul > li > p:first-child:before {
-    content: "—";
-    display: inline-block;
-    width: 1em;
-    margin-left: -1.5em;
-    margin-right: 0.5em;
-  }
+ul > li > p:first-child:before {
+  content: "—";
+  display: inline-block;
+  width: 1em;
+  margin-left: -1.5em;
+  margin-right: 0.5em;
+}
 
   li p {
       /* display: inline-block; */

--- a/lib/isodoc/iso/html/style-iso.scss
+++ b/lib/isodoc/iso/html/style-iso.scss
@@ -251,7 +251,7 @@ h2 p {
     list-style: none;
   }
   
-  ul > li > p:before {
+  ul > li > p:first-child:before {
     content: "—";
     display: inline-block;
     width: 1em;


### PR DESCRIPTION
E.g., given an Asciidoc source:

```asciidoc
something something

* Enter something:
+
[source,bash]
----
test
----

* something:
+
[source,bash]
----
test
----
```

## Result (screenshot)

![failure](https://user-images.githubusercontent.com/2649467/45862145-fa826000-bda2-11e8-8f44-0916028733ac.png)


## Expected result (screenshot)

![success](https://user-images.githubusercontent.com/2649467/45862617-1dae0f00-bda5-11e8-967f-197e2138308d.png)
